### PR TITLE
set default oneway to false, except roundabouts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.1.17"
+version = "0.1.18"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -162,8 +162,8 @@ const DEFAULT_LANES = Dict(
 Default oneway attribute based on highway type. 
 """
 const DEFAULT_ONEWAY = Dict(
-    "motorway" => true,
-    "trunk" => true,
+    "motorway" => false,
+    "trunk" => false,
     "primary" => false,
     "secondary" => false,
     "tertiary" => false,


### PR DESCRIPTION
Per discussion with @captchanjack  default tagging for all ways without oneway should be false, as in most osm editors when you create a road it defaults to twoway (assume oneway to be no) - and will explicitly add the oneway tag when you then set the road to oneway. 
https://www.openstreetmap.org/way/51812001#map=16/-37.7196/145.0830 

and the same view in the editor:

![image](https://user-images.githubusercontent.com/8016236/136890328-52ccacb8-b041-426e-8890-251a0b638d96.png)
