### PR TITLE
node_to_way relationship contained duplicate ways when only considering the largest connected component 

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -215,7 +215,10 @@ function add_node_and_edge_mappings!(g::OSMGraph{U,T,W}) where {U <: Integer,T <
             end                
         end
     end
-
+    
+    # remove duplicates
+    g.node_to_way = Dict{T, Vector{T}}(key => collect(Set(value)) for (key, value) in g.node_to_way)
+    
     @assert(length(g.nodes) == length(g.node_to_way), "Data quality issue: number of graph nodes ($(length(g.nodes::Dict{T,Node{T}}))) not equal to set of nodes extracted from ways ($(length(g.node_to_way)))")
     g.node_to_index = OrderedDict{T,U}(n => i for (i, n) in enumerate(collect(keys(g.nodes))))
     g.index_to_node = OrderedDict{U,T}(i => n for (n, i) in g.node_to_index)


### PR DESCRIPTION
I noticed that, when I create a OSMGraph object like this:
```
using LightOSM
data = download_osm_network(:bbox; minlat=52.89, minlon=-1.2, maxlat=52.92, maxlon=-1.165)
g = graph_from_object(data, weight_type=:distance)
```
the values of `g.node_to_way` would contain every way the corresponding key is part of twice. I believe I narrowed it down to the fact, that in this case above, `largest_connected_component=true`.
 So when rebuilding the mappings in `trim_to_largest_connected_component!(...)` we would again call `add_node_and_edge_mappings!(...)`, which only adds to the dict, without checking if the ways have already been added.

I fixed this problem, by explicitly converting and then collecting the values of g.node_to_way  to a set, at the end of every call to `add_node_and_edge_mappings!(...)`
