### PR TITLE
Added lanes:forward, lanes:backward and lanes:both_ways to default tags

### DIFF
--- a/docs/src/defaults.md
+++ b/docs/src/defaults.md
@@ -1,4 +1,66 @@
 # Default Values
+## Ways
+During parsing, only `way`s with tags and nodes are considered. Further, the tags have to contain a key of either `"highway"` or `"railway"`. If the tags contain tags which have been excluded due to the `network_type` keyword (e.g. on download) are also discarded. This is relevant, if you downloaded the full network and want to generate only the `:bike` network from it.
+
+### Highways
+The returned `Way` is guaranteed to have the following `keys`:
+- (`highway::String`)
+- `maxspeed::DEFAULT_OSM_MAXSPEED_TYPE` 
+    - If the tag exists before parsing, `LightOSM` attempts to parse the content to a number in km/h, while automatically converting units of `mph`. If multiple speeds are mapped, the average is returned. 
+    - If the tag does not exist before parsing, the default value as given by `DEFAULT_MAXSPEEDS[tags["highway"]]` is returned. If there is no tag with key `"highway"` in `DEFAULT_MAXSPEEDS`, then `DEFAULT_MAXSPEEDS["other"]` is used.
+- `oneway::Bool` 
+- `reverseway::Bool`
+- `lanes::DEFAULT_OSM_LANES_TYPE`
+    - If the tag exists before parsing, `LightOSM` attempts to parse the content to a `DEFAULT_OSM_LANES_TYPE`
+    - If the tag does not exist before parsing, the default value as given by `DEFAULT_LANES[tags["highway"]]` is returned. If there is no tag with key `"highway"` in `DEFAULT_LANES`, then `DEFAULT_LANES["other"]` is used.
+
+- `lanes:forward::DEFAULT_OSM_LANES_TYPE`
+    - If the way is `oneway` and `reverseway` this value is 0
+    - If the way is `oneway` and not `reverseway` this value is the same as the `lanes` tag
+    - If the way is not `oneway`, the value is parsed like `lanes`, but with `"lanes"=>"lanes:forward"`
+
+- `lanes:backward::DEFAULT_OSM_LANES_TYPE`
+    - If the way is `oneway` and not `reverseway` this value is 0
+    - If the way is `oneway` and `reverseway` this value is the same as the `lanes` tag
+    - If the way is not `oneway`, the value is parsed like `lanes`, but with `"lanes"=>"lanes:backward"`
+
+- `lanes:both_ways::DEFAULT_OSM_LANES_TYPE`
+    - If the way is `oneway`, this value is 0
+    - If the way is not `oneway`:
+        - If the tag exists before parsing, `LightOSM` attempts to parse the content to a `DEFAULT_OSM_LANES_TYPE`
+        - If the tag does not exist before parsing, the default value as given by `DEFAULT_LANES_BOTH_WAYS[tags["highway"]]` is returned. If there is no tag with key `"highway"` in `DEFAULT_LANES_BOTH_WAYS`, `DEFAULT_LANES_BOTH_WAYS["other"]` is used. 
+
+all further tags present on the original way are preserved, but not parsed to appropriate datatypes, but rather left as `String`.
+
+See [here](https://github.com/DeloitteOptimalReality/LightOSM.jl/blob/master/src/parse.jl#L4) for the full implementation of the `maxspeed` parsing, and [here](https://github.com/DeloitteOptimalReality/LightOSM.jl/blob/master/src/parse.jl#L56) for the full implementation of any `lanes` parsing.
+
+### Railways
+The returned `Way` is guaranteed to have the following `keys`:
+- (`railway::String`)
+- `rail_type::String` set to `"unknown"` if not mapped
+- `electrified::String` set to `"unknown"` if not mapped
+- `gauge::Union{String, Nothin}` set to `nothing` if not mapped
+- `usage::String` set to `"unknown"` if not mapped
+- `name::String` set to `"unknown"` if not mapped
+- `lanes::Union{String, Int64}` set to `1` if not mapped.
+- `maxspeed::DEFAULT_OSM_MAXSPEED_TYPE`
+- `oneway::DEFAULT_OSM_LANES_TYPE`
+- `reverseway::DEFAULT_OSM_LANES_TYPE`
+
+all further tags present on the original `way` are preserved, but not parsed to appropriate datatypes, but rather left as `String`.
+
+The tags `maxspeed`, `oneway` and `reverseway` are set in the same way as described in [highways](#Highways).
+
+## Buildings
+During parsing, only `relation`s and `way`s with tags, where one of these tags has to have a key of `"building"` are considered. After parsing, the following `keys` are guaranteed to exist:
+- (`building`)
+- `height` (see [here](https://github.com/DeloitteOptimalReality/LightOSM.jl/blob/master/src/buildings.jl#L171) for source)
+
+The height value is parsed via the funcitno 
+
+
+all further tags present in the original object are preserved, but not parsed to appropriate datatypes, but rather left as `String`.
+
 
 ```@docs
 LightOSM.set_defaults

--- a/docs/src/defaults.md
+++ b/docs/src/defaults.md
@@ -34,6 +34,8 @@ all further tags present on the original way are preserved, but not parsed to ap
 
 See [here](https://github.com/DeloitteOptimalReality/LightOSM.jl/blob/master/src/parse.jl#L4) for the full implementation of the `maxspeed` parsing, and [here](https://github.com/DeloitteOptimalReality/LightOSM.jl/blob/master/src/parse.jl#L56) for the full implementation of any `lanes` parsing.
 
+Also note that the `lanes` tag is interpreted as the number of lanes in one direction of the road. This conflicts with the official [OSM documentation](https://wiki.openstreetmap.org/wiki/Key:lanes?uselang=en). If you need accurate numbers of lanes in both directions, you want to use `lanes:forward` and `lanes:backward`. This discrepancy will be fixed in future releases.
+
 ### Railways
 The returned `Way` is guaranteed to have the following `keys`:
 - (`railway::String`)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -168,6 +168,14 @@ const DEFAULT_LANES = Ref(Dict{String,DEFAULT_OSM_LANES_TYPE}(
 ))
 
 """
+Default number of lanes:both_ways based in highway type.
+"""
+const DEFAULT_LANES_BOTH_WAYS = Ref(Dict{String,DEFAULT_OSM_LANES_TYPE}(
+    "other" => 0
+))
+
+
+"""
 Default oneway attribute based on highway type. 
 """
 const DEFAULT_ONEWAY = Dict(
@@ -225,8 +233,8 @@ optional.
 
 # Keyword Arguments
 - `maxspeeds::AbstractDict{String,<:Real}`: If no `maxspeed` way tag is available, these 
-    values are used instead based on the value of the `highway` way tag. If no 
-    `highway` way tag is available, the value for `"other"` is used. Unit is km/h. 
+    values are used instead based on the value of the `highway` way tag. If the value of the
+    `highway` tag is not a key of the dictionary, the value for `"other"` is used. Unit is km/h. 
     Default value: 
     ```
     Dict(
@@ -241,8 +249,8 @@ optional.
     )
     ```
 - `lanes::AbstractDict{String,<:Integer}`: If no `lanes` way tag is available, these 
-    values are used instead based on the value of the `highway` way tag. If no 
-    `highway` way tag is available, the value for `"other"` is used. 
+    values are used instead based on the value of the `highway` way tag.  If the value of the
+    `highway` tag is not a key of the dictionary, the value for `"other"` is used.
     Default value: 
     ```
     Dict(
@@ -254,6 +262,15 @@ optional.
         "unclassified" => 1,
         "residential" => 1,
         "other" => 1
+    )
+    ```
+- `lanes_both_ways::AbstractDict{String,<:Integer}`: If no `lanes:both_ways` tag is available, these
+    values are used instead, based on the value of the `highway` way tag.  If the value of the
+    `highway` tag is not a key of the dictionary, the value for `"other"` is used.
+    Default value:
+    ```
+    Dict(
+        "other" => 0
     )
     ```
 - `lane_efficiency::AbstractDict{<:Integer,<:Real}`: Gives the lane efficiency based on 
@@ -282,12 +299,14 @@ optional.
 function set_defaults(;
                       maxspeeds::AbstractDict{String,<:Real}=DEFAULT_MAXSPEEDS[],
                       lanes::AbstractDict{String,<:Integer}=DEFAULT_LANES[],
+                      lanes_both_ways::AbstractDict{String,<:Integer}=DEFAULT_LANES_BOTH_WAYS[],
                       lane_efficiency::AbstractDict{<:Integer,<:Real}=LANE_EFFICIENCY[],
                       building_height_per_level::Real=DEFAULT_BUILDING_HEIGHT_PER_LEVEL[],
                       max_building_levels::Integer=DEFAULT_MAX_BUILDING_LEVELS[]
                       )
     DEFAULT_MAXSPEEDS[] = maxspeeds
     DEFAULT_LANES[] = lanes
+    DEFAULT_LANES_BOTH_WAYS[] = lanes_both_ways
     LANE_EFFICIENCY[] = lane_efficiency
     DEFAULT_BUILDING_HEIGHT_PER_LEVEL[] = building_height_per_level
     DEFAULT_MAX_BUILDING_LEVELS[] = max_building_levels

--- a/test/stub.jl
+++ b/test/stub.jl
@@ -40,10 +40,10 @@ function basic_osm_graph_stub(weight_type=:distance, graph_type=:static)
         [1008, 1007],
     ]
     tag_dicts = [
-        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(2)),
-        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(100), "lanes" => Int8(4)),
-        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(2)),
-        Dict{String, Any}("oneway" => true,  "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(1)),
+        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(2), "lanes:forward"=>Int8(2), "lanes:backward"=>Int8(2), "lanes:both_ways"=>Int8(0)),
+        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(100), "lanes" => Int8(4), "lanes:forward"=>Int8(3), "lanes:backward"=>Int8(3), "lanes:both_ways"=>Int8(2)),
+        Dict{String, Any}("oneway" => false, "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(2), "lanes:forward"=>Int8(3), "lanes:backward"=>Int8(1), "lanes:both_ways"=>Int8(0)),
+        Dict{String, Any}("oneway" => true,  "reverseway" => false, "maxspeed" => Int16(50),  "lanes" => Int8(1), "lanes:forward"=>Int8(1), "lanes:backward"=>Int8(0), "lanes:both_ways"=>Int8(0)),
     ]
     ways = Dict(way_id => Way(way_id, nodes, tag_dict) for (way_id, nodes, tag_dict) in zip(way_ids, way_nodes, tag_dicts))
 


### PR DESCRIPTION
As discussed in issue #86, I added the parsing for the tags `lanes:forward`, `lanes:backward` and `lanes:both_ways`, to provide a clearer picture of the number of lanes actually present, without breaking the old behaviour of the `lanes` tag.

I added documentation as to how we parse all the default tags (this probably needs some love... I feel it might be clearer, if we just copy the whole source of every parsing function into the docs)

In addition, I added some code to used the new tags during weight adding, as described in point 2.
Let me know what you think about it.