### PR TITLE
[FEAT] Add GeoLocation constructor from EdgePoint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -55,7 +55,7 @@ function graph_from_object(osm_data_object::Union{XMLDocument,Dict};
         g.dijkstra_states = Vector{Vector{U}}(undef, length(g.nodes))
     end
 
-    add_kdtree!(g)
+    add_kdtree_and_rtree!(g)
     @info "Created OSMGraph object with kwargs: `network_type=$network_type`, `weight_type=$weight_type`, `graph_type=$graph_type`, `precompute_dijkstra_states=$precompute_dijkstra_states`, `largest_connected_component=$largest_connected_component`"
     return g
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,16 +1,22 @@
 """
 Representation of a geospatial coordinates.
 
+# Fields
 - `lat::Float64`: Latitude.
 - `lon::Float64`: Longitude.
 - `alt::Float64`: Altitude.
+
+# Constructors
+    GeoLocation(lat, lon)
+    GeoLocation(point::Vector{<:Real})
+    GeoLocation(point_vector::Vector{<:Vector{<:Real}})
+    GeoLocation(g::OSMGraph, ep::EdgePoint)
 """
 @with_kw_noshow struct GeoLocation
     lat::Float64
     lon::Float64
     alt::Float64 = 0.0
 end
-
 GeoLocation(lat::AbstractFloat, lon::AbstractFloat)::GeoLocation = GeoLocation(lat=lat, lon=lon)
 GeoLocation(lat::Real, lon::Real)::GeoLocation = GeoLocation(lat=float(lat), lon=float(lon))
 GeoLocation(point::Vector{<:AbstractFloat})::GeoLocation = GeoLocation(point...)
@@ -19,6 +25,9 @@ GeoLocation(point_vector::Vector{<:Vector{<:Real}})::Vector{GeoLocation} = [GeoL
 
 function Base.:(==)(loc1::GeoLocation, loc2::GeoLocation)
     return loc1.lat == loc2.lat && loc1.lon == loc2.lon && loc1.alt == loc2.alt
+end
+function Base.isapprox(loc1::GeoLocation, loc2::GeoLocation)
+    return loc1.lat ≈ loc2.lat && loc1.lon ≈ loc2.lon && loc1.alt ≈ loc2.alt
 end
 function Base.hash(loc::GeoLocation, h::UInt)
     for field in fieldnames(GeoLocation)
@@ -30,6 +39,7 @@ end
 """
 OpenStreetMap node.
 
+# Fields
 `T<:Integer`
 - `id::T`: OpenStreetMap node id.
 - `nodes::Vector{T}`: Node's GeoLocation.
@@ -44,6 +54,7 @@ end
 """
 OpenStreetMap way.
 
+# Fields
 `T<:Integer`
 - `id::T`: OpenStreetMap way id.
 - `nodes::Vector{T}`: Ordered list of node ids making up the way.
@@ -75,6 +86,7 @@ end
 """
 OpenStreetMap turn restriction (relation).
 
+# Fields
 `T<:Integer`
 - `id::T`: OpenStreetMap relation id.
 - `type::String`: Either a `via_way` or `via_node` turn restriction.
@@ -101,6 +113,7 @@ end
 """
 Container for storing OpenStreetMap node, way, relation and graph related obejcts.
 
+# Fields
 `U <: Integer,T <: Integer,W <: Real`
 - `nodes::Dict{T,Node{T}}`: Mapping of node ids to node objects.
 - `node_coordinates::Vector{Vector{W}}`: Vector of node coordinates [[lat, lon]...], indexed by graph vertices.
@@ -155,6 +168,7 @@ end
 """
 OpenStreetMap building polygon.
 
+# Fields
 `T<:Integer`
 - `id::T`: OpenStreetMap building way id.
 - `nodes::Vector{T}`: Ordered list of node ids making up the building polyogn.
@@ -169,6 +183,7 @@ end
 """
 OpenStreetMap building.
 
+# Fields
 `T<:Integer`
 - `id::T`: OpenStreetMap building way id a simple polygon, relation id if a multi-polygon
 - `is_relation::Bool`: True if building is a a multi-polygon / relation.
@@ -196,3 +211,11 @@ abstract type DijkstraDict <: Dijkstra end
 abstract type AStar <: PathAlgorithm end
 abstract type AStarVector <: AStar end
 abstract type AStarDict <: AStar end
+
+"""
+Additional GeoLocation methods that require types defined above.
+"""
+GeoLocation(g::OSMGraph, ep::EdgePoint)::GeoLocation = GeoLocation(
+    lon = g.nodes[ep.n1].location.lon + (g.nodes[ep.n2].location.lon - g.nodes[ep.n1].location.lon) * ep.pos,
+    lat = g.nodes[ep.n1].location.lat + (g.nodes[ep.n2].location.lat - g.nodes[ep.n1].location.lat) * ep.pos
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ const TEST_OSM_URL = "https://raw.githubusercontent.com/DeloitteOptimalReality/L
     @testset "Graph" begin include("graph.jl") end
     @testset "Traversal" begin include("traversal.jl") end
     @testset "Subgraph" begin include("subgraph.jl") end
+    @testset "Types" begin include("types.jl") end
 end

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,0 +1,8 @@
+g = basic_osm_graph_stub()
+
+@testset "GeoLocation tests" begin
+    ep = LightOSM.EdgePoint(1003, 1004, 0.4)
+    expected_response = GeoLocation(lon=145.3326838, lat=-38.0754037)
+    actual_response = GeoLocation(g, ep)
+    @test expected_response ≈ actual_response
+end


### PR DESCRIPTION
Add a method to easily get the coordinates of an `EdgePoint`.

```julia
julia> ep = EdgePoint(6913853675, 144699879, 0.5)  # Half-way between nodes 6913853675 and 144699879
julia> GeoLocation(g, ep)
GeoLocation(-37.81912355, 144.9580393, 0.0)
```
