### PR TITLE
[FIX] Ensure "lanes" tag for railway type is converted to Int8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -201,7 +201,8 @@ function parse_osm_network_dict(osm_network_dict::AbstractDict, network_type::Sy
     U = DEFAULT_OSM_INDEX_TYPE
     T = DEFAULT_OSM_ID_TYPE
     W = DEFAULT_OSM_EDGE_WEIGHT_TYPE
-    
+    L = DEFAULT_OSM_LANES_TYPE
+
     ways = Dict{T,Way{T}}()
     highway_nodes = Set{Int}([])
     for way in osm_network_dict["way"]
@@ -222,7 +223,7 @@ function parse_osm_network_dict(osm_network_dict::AbstractDict, network_type::Sy
                 tags["gauge"] = get(tags, "gauge", nothing)
                 tags["usage"] = get(tags, "usage",  "unknown")
                 tags["name"] = get(tags, "name", "unknown")
-                tags["lanes"] = get(tags, "tracks", 1)
+                tags["lanes"] = L(get(tags, "tracks", 1))
                 tags["maxspeed"] = maxspeed(tags)
                 tags["oneway"] = is_oneway(tags)
                 tags["reverseway"] = is_reverseway(tags)


### PR DESCRIPTION
Fixes parsing issue when dealing with railway networks, this commit will ensure lanes are converted to the required type (Int8)

Should #51