### PR TITLE
Only look at members that are ways when parsing buildings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/buildings.jl
+++ b/src/buildings.jl
@@ -210,7 +210,8 @@ function parse_osm_buildings_dict(osm_buildings_dict::AbstractDict)::Dict{Intege
             members = relation["members"]
             
             polygons = Vector{Polygon{T}}()
-            for member in members
+            for member in members 
+                member["type"] != "way" && continue
                 way_id = member["ref"]
                 way = ways[way_id]
 


### PR DESCRIPTION
Closes #94 

@captchanjack are we losing any important information by ignoring `node`s and anything else that is a member of a way here?