### PR TITLE
Fix lane parsing bug

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -227,7 +227,7 @@ function parse_osm_network_dict(osm_network_dict::AbstractDict,
                 tags["gauge"] = get(tags, "gauge", nothing)
                 tags["usage"] = get(tags, "usage",  "unknown")
                 tags["name"] = get(tags, "name", "unknown")
-                tags["lanes"] = L(get(tags, "tracks", 1))
+                tags["lanes"] = lanes(tags)
                 tags["maxspeed"] = maxspeed(tags)
                 tags["oneway"] = is_oneway(tags)
                 tags["reverseway"] = is_reverseway(tags)

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -9,3 +9,13 @@ graphs = [
     @test g.edge_to_way === g.edge_to_way
     end
 end
+@testset "Regression test for railway lane parsing" begin
+    g = graph_from_download(
+        :place_name,
+        place_name = "bern, switzerland",
+        network_type = :rail,
+        weight_type = :distance
+    )
+    _, way = rand(g.ways)
+    @test way.tags["lanes"] isa Integer
+end


### PR DESCRIPTION
Parsing railways fails on master:
```julia
graph = graph_from_download(
    :place_name; place_name="bern, switzerland", network_type=:rail, weight_type=:distance
)
```
This PR fixes this bug by using the `lanes` function in the railway branch. I also added a regression test.
Could we get a release with this bugfix? If v0.3.0 is being blocked, maybe we could backport this bugfix onto v0.2.x?