### PR TITLE
Generalize utility function methods

### DIFF
--- a/src/graph_utilities.jl
+++ b/src/graph_utilities.jl
@@ -4,8 +4,8 @@
 
 Maps node index to node id.
 """
-index_to_node_id(g::OSMGraph, x::DEFAULT_OSM_INDEX_TYPE) = g.index_to_node[x]
-index_to_node_id(g::OSMGraph, x::Vector{<:DEFAULT_OSM_INDEX_TYPE}) = [index_to_node_id(g, i) for i in x]
+index_to_node_id(g::OSMGraph{U}, x::U) where U = g.index_to_node[x]
+index_to_node_id(g::OSMGraph{U}, x::Vector{<:U}) where U = [index_to_node_id(g, i) for i in x]
 
 """
     index_to_node(g::OSMGraph, x::DEFAULT_OSM_INDEX_TYPE)
@@ -13,8 +13,8 @@ index_to_node_id(g::OSMGraph, x::Vector{<:DEFAULT_OSM_INDEX_TYPE}) = [index_to_n
 
 Maps node index to node object.
 """
-index_to_node(g::OSMGraph, x::DEFAULT_OSM_INDEX_TYPE) = g.nodes[g.index_to_node[x]]
-index_to_node(g::OSMGraph, x::Vector{<:DEFAULT_OSM_INDEX_TYPE}) = [index_to_node(g, i) for i in x]
+index_to_node(g::OSMGraph{U}, x::U) where U = g.nodes[g.index_to_node[x]]
+index_to_node(g::OSMGraph{U}, x::Vector{<:U}) where U = [index_to_node(g, i) for i in x]
 
 """
     node_id_to_index(g::OSMGraph, x::DEFAULT_OSM_ID_TYPE)
@@ -22,8 +22,8 @@ index_to_node(g::OSMGraph, x::Vector{<:DEFAULT_OSM_INDEX_TYPE}) = [index_to_node
 
 Maps node id to index.
 """
-node_id_to_index(g::OSMGraph, x::DEFAULT_OSM_ID_TYPE) = g.node_to_index[x]
-node_id_to_index(g::OSMGraph, x::Vector{<:DEFAULT_OSM_ID_TYPE}) = [node_id_to_index(g, i) for i in x]
+node_id_to_index(g::OSMGraph{U,T}, x::T) where {U,T} = g.node_to_index[x]
+node_id_to_index(g::OSMGraph{U,T}, x::Vector{<:T}) where {U,T} = [node_id_to_index(g, i) for i in x]
 """
     node_to_index(g::OSMGraph, x::Node)
     node_to_index(g::OSMGraph, x::Vector{Node})
@@ -38,30 +38,30 @@ node_to_index(g::OSMGraph, x::Vector{Node}) = [node_id_to_index(g, i.id) for i i
 
 Maps node index to dijkstra state (parents).
 """
-index_to_dijkstra_state(g::OSMGraph, x::DEFAULT_OSM_INDEX_TYPE) = g.dijkstra_states[x]
+index_to_dijkstra_state(g::OSMGraph{U}, x::U) where U = g.dijkstra_states[x]
 """
     node_id_to_dijkstra_state(g::OSMGraph, x::DEFAULT_OSM_ID_TYPE)
 
 Maps node id to dijkstra state (parents).
 """
-node_id_to_dijkstra_state(g::OSMGraph, x::DEFAULT_OSM_ID_TYPE) = g.dijkstra_states[node_id_to_index(g, x)]
+node_id_to_dijkstra_state(g::OSMGraph{U,T}, x::T) where {U,T} = g.dijkstra_states[node_id_to_index(g, x)]
 """
     set_dijkstra_state_with_index!(g::OSMGraph, index::DEFAULT_OSM_INDEX_TYPE, state)
 
 Set dijkstra state (parents) with node index.
 """
-set_dijkstra_state_with_index!(g::OSMGraph, index::DEFAULT_OSM_INDEX_TYPE, state) = push!(g.dijkstra_states, index, state)
+set_dijkstra_state_with_index!(g::OSMGraph{U}, index::U, state) where U = push!(g.dijkstra_states, index, state)
 """
     set_dijkstra_state_with_node_id!(g::OSMGraph, index::DEFAULT_OSM_ID_TYPE, state)
 
 Set dijkstra state (parents) with node id.
 """
-set_dijkstra_state_with_node_id!(g::OSMGraph, node_id::DEFAULT_OSM_ID_TYPE, state) = push!(g.dijkstra_states, node_id_to_index(g, node_id), state)
+set_dijkstra_state_with_node_id!(g::OSMGraph{U,T}, node_id::T, state) where {U,T} = push!(g.dijkstra_states, node_id_to_index(g, node_id), state)
 """
     maxspeed_from_index(g, x::DEFAULT_OSM_INDEX_TYPE)
     maxspeed_from_node_id(g, x::DEFAULT_OSM_ID_TYPE)
 
 Get maxspeed from index id or node id.
 """
-maxspeed_from_index(g, x::DEFAULT_OSM_INDEX_TYPE) = index_to_node(g, x).tags["maxspeed"]
-maxspeed_from_node_id(g, x::DEFAULT_OSM_ID_TYPE) = g.nodes[x].tags["maxspeed"]
+maxspeed_from_index(g::OSMGraph{U}, x::U) where U = index_to_node(g, x).tags["maxspeed"]
+maxspeed_from_node_id(g::OSMGraph{U,T}, x::T) where {U,T} = g.nodes[x].tags["maxspeed"]


### PR DESCRIPTION
Ostensibly, since `OSMGraph` instances can be constructed that have index or node id types different from the default, it should also be possible to use the utilities with the corresponding types.

Maybe they could be generalized even further (e.g. to `Integer` and `Union{Integer, String}`), since the `Dict` access will promote them if possible.