### PR TITLE
Ignore empty roles in restriction validity check

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -134,6 +134,9 @@ function is_valid_restriction(members::AbstractArray, ways::AbstractDict{T,Way{T
         type = member["type"]
         role = member["role"]
 
+        # Members with missing role can be ignored
+        isempty(role) && continue
+
         if type == "way"
             if !haskey(ways, id) || id in ways_set
                 # Cannot process missing and duplicate from/via/to ways


### PR DESCRIPTION
There are sometimes duplicate ways without roles in restriction relations, e.g. [here](https://www.openstreetmap.org/relation/8275505#map=18/47.071052/8.285231). Arguably they do not make the restriction invalid and can be ignored as long as all required roles are defined. This PR adds a `continue` in the loop over members.