### PR TITLE
work with empty nodes/ways

### DIFF
--- a/test/data/empty.osm
+++ b/test/data/empty.osm
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<osm version="0.6" generator="LightOSM.jl">
+  <count id="0">
+    <tag k="nodes" v="0"/>
+    <tag k="ways" v="0"/>
+    <tag k="relations" v="0"/>
+    <tag k="total" v="0"/>
+  </count>
+</osm>

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,0 +1,5 @@
+@testset "parse empty osm file" begin 
+    xml = LightXML.parse_file(joinpath(@__DIR__, "data", "empty.osm"))
+    graph = graph_from_object(xml)
+    @test isempty(graph.nodes)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ const TEST_OSM_URL = "https://raw.githubusercontent.com/DeloitteOptimalReality/L
 @testset "LightOSM Tests" begin 
     @testset "Constants" begin include("constants.jl") end
     @testset "Utilities" begin include("utilities.jl") end
+    @testset "Parse" begin include("parse.jl") end
     @testset "Geometry" begin include("geometry.jl") end
     @testset "Download" begin include("download.jl") end
     @testset "Nearest Node" begin include("nearest_node.jl") end


### PR DESCRIPTION
The parsing functionality worked with empty relations but failed for empty nodes or ways. This is now fixed with a small test case.