### PR TITLE
fix: avoid unwanted keywords for Restriction struct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 authors = ["Jack Chan <jchan2@deloitte.com.au>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -250,8 +250,9 @@ function parse_osm_network_dict(osm_network_dict::AbstractDict,
             )
         end
     end
-    
+
     restrictions = Dict{T,Restriction{T}}()
+    restriction_fields = fieldnames(Restriction)
     if haskey(osm_network_dict, "relation")
         for relation in osm_network_dict["relation"]
             if haskey(relation, "tags") && haskey(relation, "members")
@@ -262,6 +263,9 @@ function parse_osm_network_dict(osm_network_dict::AbstractDict,
                     restriction_kwargs = DefaultDict(Vector)
                     for member in members
                         key = "$(member["role"])_$(member["type"])"
+                        if !(Symbol(key) in restriction_fields)
+                            continue
+                        end
                         if key == "via_way"
                             push!(restriction_kwargs[Symbol(key)], member["ref"])
                         else


### PR DESCRIPTION
Hey I found an edge case so that a relation belongs to another relation, hence it make the Restriction struct error with unwanted keywork.
This PR is to fix that problem