### PR TITLE
fix CI: `isdefined` -> `isassigned` and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/src/subgraph.jl
+++ b/src/subgraph.jl
@@ -41,7 +41,7 @@ function osm_subgraph(g::OSMGraph{U, T, W},
     add_graph!(osg, get_graph_type(g))
     add_node_tags!(osg)
 
-    if isdefined(g.dijkstra_states, 1)
+    if !isnothing(g.dijkstra_states) && isassigned(g.dijkstra_states, 1)
         add_dijkstra_states!(osg)
     else
         osg.dijkstra_states = Vector{Vector{U}}(undef, length(osg.nodes))

--- a/test/subgraph.jl
+++ b/test/subgraph.jl
@@ -13,8 +13,8 @@ graphs = [
         @test sg.ways == g.ways
         @test sg.restrictions == g.restrictions
         @test sg.weight_type == g.weight_type
-        @test isdefined(sg.dijkstra_states, 1) == isdefined(g.dijkstra_states, 1)
-        if isdefined(g.dijkstra_states, 1)
+        @test isassigned(sg.dijkstra_states, 1) == isassigned(g.dijkstra_states, 1)
+        if isassigned(g.dijkstra_states, 1)
             @test sg.dijkstra_states == g.dijkstra_states
         end
         @test isdefined(sg.kdtree, 1) == isdefined(g.kdtree, 1)


### PR DESCRIPTION
## Summary

- **Fix**: `osm_subgraph` and the Subgraph testset relied on `isdefined(::Vector, i)` to detect populated dijkstra slots. Julia 1.11+ changed that to a bounds-only check (Vectors back onto `Memory{T}` now), so it always returns `true` for valid indices. Switched to `isassigned`, which preserves the original semantics. Without this, the Subgraph tests have been failing on Julia 1 (stable) since the runner-level "Set up job" failures were fixed in #118.
- **Dependabot**: weekly grouped updates for `github-actions` so future action-version drift gets caught before it bites CI.

## Verified

- Subgraph testset locally on Julia 1.12.6: 24/24 (was 24 + 2 errored on master)
- Other offline testsets unaffected

## Out of scope

- Separate Windows-only failure at `test/download.jl:47` (`SystemError: opening file "map.json": Invalid argument`). Not addressed here — file-path/locking on Windows, unrelated to the Julia regression. Will pop out on its own once stable Julia 1 turns green.

## Test plan

- [ ] CI matrix (Julia 1 + nightly × ubuntu + windows) green for the dijkstra_states fix
- [ ] Confirm Windows download test status

🤖 Generated with [Claude Code](https://claude.com/claude-code)